### PR TITLE
Fix tab component demo

### DIFF
--- a/samples/tabs/tabs-component.html
+++ b/samples/tabs/tabs-component.html
@@ -237,7 +237,7 @@
                 }
                 this.updateCurrent();
             }
-        }
+        };
 
         }
 

--- a/samples/tabs/tabs-component.html
+++ b/samples/tabs/tabs-component.html
@@ -7,8 +7,7 @@
 <body>
 <element name="tabs" extends="article" constructor="TabsControl">
     <template>
-        <style>
-
+        <style id="exportedStyle">
             h2:nth-of-type(1) {
                 background: white;
                 color: black;
@@ -50,24 +49,24 @@
         <style>
             @import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600);
         </style>
-        <style scoped>
+        <style>
             div.container {
-                display: -webkit-flexbox;
+                display: -webkit-flex;
                 -webkit-flex-direction: column;
-                -webkit-flex-align: stretch;
+                -webkit-align-items: stretch;
                 background: -webkit-linear-gradient(rgb(230, 230, 230), rgb(200, 200, 200));
                 padding: 10px; -webkit-font-smoothing: antialiased;
             }
 
             .tab-strip {
-                display: -webkit-flexbox;
-                -webkit-flex-pack: justify;
+                display: -webkit-flex;
+                -webkit-justify-content: space-between;
                 padding: 0 5px;
                 -webkit-user-select: none;
             }
 
             .tab-wrapper {
-                display: -webkit-flexbox;
+                display: -webkit-flex;
                 height: 30px;
             }
 
@@ -80,8 +79,8 @@
             }
 
             div.more {
-                display: -webkit-flexbox;
-                -webkit-flex-pack: justify;
+                display: -webkit-flex;
+                -webkit-justify-content: space-between;
                 padding: 0 5px;
                 -webkit-user-select: none;
             }
@@ -151,9 +150,13 @@
         this.lifecycle({
             created: function(root) {
                 this.root = root;
+
+                var exportedStyle = this.root.querySelector('#exportedStyle');
+                exportedStyle = this.appendChild(exportedStyle);
+                this.outerStylesheet = exportedStyle.sheet;
+
                 this.currentIndex = 1;
                 this.moreOpened = false;
-                this.outerStylesheet = this.root.querySelector('style').sheet;
                 this.current = this.root.querySelector('content.current');
                 var overflow = this.root.querySelector('.overflow');
                 overflow.addEventListener('click', this.onClickOverflow.bind(this));

--- a/src/components-polyfill.js
+++ b/src/components-polyfill.js
@@ -1,6 +1,6 @@
 (function(scope) {
 
-var scope = scope || {};
+scope = scope || {};
 
 var SCRIPT_SHIM = ['(function(){\n', 1, '\n}).call(this.element);'];
 
@@ -12,9 +12,9 @@ if (!window.WebKitShadowRoot) {
 
 scope.HTMLElementElement = function(name, tagName, declaration) {
   this.name = name;
-  this.extends = tagName;
+  this.extendsTagName = tagName;
   this.lifecycle = this.lifecycle.bind(declaration);
-}
+};
 
 scope.HTMLElementElement.prototype = {
   __proto__: HTMLElement.prototype,
@@ -35,19 +35,19 @@ scope.Declaration = function(name, tagName) {
   this.element.generatedConstructor = this.generateConstructor();
   // Hard-bind the following methods to "this":
   this.morph = this.morph.bind(this);
-}
+};
 
 scope.Declaration.prototype = {
 
   generateConstructor: function() {
-    var tagName = this.element.extends;
+    var tagName = this.element.extendsTagName;
     var created = this.created;
     var extended = function() {
       var element = document.createElement(tagName);
       extended.prototype.__proto__ = element.__proto__;
       element.__proto__ = extended.prototype;
       created.call(element);
-    }
+    };
     extended.prototype = this.elementPrototype;
     return extended;
   },
@@ -64,7 +64,7 @@ scope.Declaration.prototype = {
 
   morph: function(element) {
     // FIXME: We shouldn't be updating __proto__ like this on each morph.
-    this.element.generatedConstructor.prototype.__proto__ = document.createElement(this.element.extends);
+    this.element.generatedConstructor.prototype.__proto__ = document.createElement(this.element.extendsTagName);
     element.__proto__ = this.element.generatedConstructor.prototype;
     var shadowRoot = this.createShadowRoot(element);
 
@@ -92,7 +92,7 @@ scope.Declaration.prototype = {
 
   createShadowRoot: function(element) {
     if (!this.template) {
-      return;
+      return undefined;
     }
 
     var shadowRoot = new WebKitShadowRoot(element);
@@ -107,13 +107,13 @@ scope.Declaration.prototype = {
   prototypeFromTagName: function(tagName) {
     return Object.getPrototypeOf(document.createElement(tagName));
   }
-}
+};
 
 
 scope.DeclarationFactory = function() {
   // Hard-bind the following methods to "this":
   this.createDeclaration = this.createDeclaration.bind(this);
-}
+};
 
 scope.DeclarationFactory.prototype = {
   // Called whenever each Declaration instance is created.
@@ -123,7 +123,7 @@ scope.DeclarationFactory.prototype = {
     var name = element.getAttribute('name');
     if (!name) {
       // FIXME: Make errors more friendly.
-      console.error('name attribute is required.')
+      console.error('name attribute is required.');
       return;
     }
     var tagName = element.getAttribute('extends');
@@ -145,12 +145,12 @@ scope.DeclarationFactory.prototype = {
     template && declaration.addTemplate(template);
     this.oncreate && this.oncreate(declaration);
   }
-}
+};
 
 
 scope.Parser = function() {
   this.parse = this.parse.bind(this);
-}
+};
 
 scope.Parser.prototype = {
   // Called for each element that's parsed.
@@ -163,12 +163,12 @@ scope.Parser.prototype = {
       this.onparse && this.onparse(element);
     }, this);
   }
-}
+};
 
 
 scope.Loader = function() {
   this.start = this.start.bind(this);
-}
+};
 
 scope.Loader.prototype = {
   // Called for each loaded declaration.
@@ -197,7 +197,7 @@ scope.Loader.prototype = {
     });
     request.send();
   }
-}
+};
 
 scope.run = function() {
   var loader = new scope.Loader();
@@ -212,11 +212,12 @@ scope.run = function() {
   var factory = new scope.DeclarationFactory();
   parser.onparse = factory.createDeclaration;
   factory.oncreate = function(declaration) {
-    [].forEach.call(document.querySelectorAll(
-        declaration.element.extends + '[is=' + declaration.element.name +
-        ']'), declaration.morph);
-  }
-}
+    [].forEach.call(
+      document.querySelectorAll(declaration.element.extendsTagName +
+                                '[is=' + declaration.element.name + ']'),
+      declaration.morph);
+  };
+};
 
 if (!scope.runManually) {
   scope.run();

--- a/src/components-polyfill.js
+++ b/src/components-polyfill.js
@@ -96,6 +96,7 @@ scope.Declaration.prototype = {
     }
 
     var shadowRoot = new WebKitShadowRoot(element);
+    shadowRoot.host = element;
     [].forEach.call(this.template.childNodes, function(node) {
       shadowRoot.appendChild(node.cloneNode(true));
     });


### PR DESCRIPTION
These changes:

• Fix style errors identified by js2-mode (“extends” is a future reserved word in JavaScript, for example.)
• Replace out-of-date flexbox property names and values with their newer equivalents.
• Remove “scoped” from styles, since styles are implicitly scoped in Shadow DOM now.
• “Export” the h2 styles by copying them into the document. This last point is particularly icky from a component encapsulation point of view; I filed https://www.w3.org/Bugs/Public/show_bug.cgi?id=18370 .
