### PR TITLE
Add accordion sample

### DIFF
--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -71,29 +71,25 @@
 					}
 				});
 
-				this.generatedConstructor.prototype = Object.create(Object.prototype, {
-					selected: {
-						get: function() {
-							return this._selected;
-						},
-						set: function(selected) {
-							if (this._selected !== selected) {
-								if (selected === true) {
-									this.classList.add('selected');
-									this._content.classList.add('selected');
-								}
-								else {
-									this.classList.remove('selected');
-									this._content.classList.remove('selected');
-								}
-
-								this._selected = selected;
+				this.generatedConstructor.prototype = {
+					get selected() {
+						return this._selected;
+					},
+					set selected(selected) {
+						if (this._selected !== selected) {
+							if (selected === true) {
+								this.classList.add('selected');
+								this._content.classList.add('selected');
 							}
-						},
-						enumerable: true,
-						configurable: true
+							else {
+								this.classList.remove('selected');
+								this._content.classList.remove('selected');
+							}
+
+							this._selected = selected;
+						}
 					}
-				});
+				};
 			}
 		</script>
 	</element>

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -38,6 +38,9 @@
 							oldSelectedSection.selected = false;
 							clickedSection.selected = true;
 							this._selectedSection = clickedSection;
+
+							// Fire 'change' event
+							this.dispatchEvent(new Event('change'));
 						}
 					}
 				};

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -14,20 +14,22 @@
 				this.lifecycle({
 					created: function(root) {
 						this._root = root;
-						var selectedSection = this._selectedSection = this.querySelector('section');
+						this._selectedSection = this.querySelector('section');
 
 						// This setTimeout is to give the child sections time to upgrade to accordion-sections. The spec describes an 'upgrade' DOM event that should fire, but it doesn't, so this is a hack for the time being.
+						var selectedSection = this._selectedSection;
 						setTimeout(function() {
 							selectedSection.selected = true;
 						}, 10);
 
 						// Attach listeners
 						this.addEventListener('click', function(event) {
-							var clickedSection = event.target.parentElement;
+							var clickedSection = event.target.parentElement,
+								oldSelectedSection = this._selectedSection;
 							if (clickedSection.selected === false) {
-								selectedSection.selected = false;
+								oldSelectedSection.selected = false;
 								clickedSection.selected = true;
-								selectedSection = clickedSection;
+								this._selectedSection = clickedSection;
 							}
 						});
 					}

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -37,7 +37,7 @@
 	</element>
 	<element name="accordion-section" extends="section">
 		<template>
-			<style scoped>
+			<style>
 				header {
 					cursor: pointer;
 				}

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -15,6 +15,8 @@
 					created: function(root) {
 						this.root = root;
 						var selectedSection = this.selectedSection = this.querySelector('section');
+
+						// This setTimeout is to give the child sections time to upgrade to accordion-sections. The spec describes an 'upgrade' DOM event that should fire, but it doesn't, so this is a hack for the time being.
 						setTimeout(function() {
 							selectedSection.selected = true;
 						}, 10);

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Accordion Component</title>
+	<link rel="stylesheet" type="text/css" href="../../src/debug.css">
+</head>
+<body>
+	<element name="accordion" extends="div">
+		<template>
+			<content></content>
+		</template>
+		<script>
+			if (this !== window) {
+				this.lifecycle({
+					created: function(root) {
+						this.root = root;
+						var selectedSection = this.selectedSection = this.querySelector('section');
+						setTimeout(function() {
+							selectedSection.selected = true;
+						}, 10);
+
+						// Attach listeners
+						this.addEventListener('click', function(event) {
+							var clickedSection = event.target.parentElement;
+							if (clickedSection.selected === false) {
+								selectedSection.selected = false;
+								clickedSection.selected = true;
+								selectedSection = clickedSection;
+							}
+						});
+					}
+				});
+			}
+		</script>
+	</element>
+	<element name="accordion-section" extends="section">
+		<template>
+			<style scoped>
+				header {
+					cursor: pointer;
+				}
+				div {
+					display: none;
+				}
+				div.selected {
+					display: block;
+				}
+			</style>
+			<header>
+				<content select="h2:first-of-type"></content>
+			</header>
+			<div>
+				<content></content>
+			</div>
+		</template>
+		<script>
+			if (this !== window) {
+				this.lifecycle({
+					created: function(root) {
+						// Define instance properties
+						Object.defineProperties(this, {
+							_root: {
+								value: root
+							},
+							_content: {
+								value: root.querySelector('div')
+							},
+							_selected: {
+								value: false,
+								writable: true
+							}
+						});
+					}
+				});
+
+				this.generatedConstructor.prototype = Object.create(Object.prototype, {
+					selected: {
+						get: function() {
+							return this._selected;
+						},
+						set: function(selected) {
+							if (this._selected !== selected) {
+								if (selected === true) {
+									this.classList.add('selected');
+									this._content.classList.add('selected');
+								}
+								else {
+									this.classList.remove('selected');
+									this._content.classList.remove('selected');
+								}
+
+								this._selected = selected;
+							}
+						},
+						enumerable: true,
+						configurable: true
+					}
+				});
+			}
+		</script>
+	</element>
+</body>
+</html>

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -14,7 +14,7 @@
 				this.lifecycle({
 					created: function(root) {
 						// Set instance properties
-						this._selectedSection = this.querySelector('section');
+						this._selectedSection = this.querySelector('.selected') || this.querySelector('section');
 
 						// Select firstChild if it has been upgraded to accordion-section by looking for a value of 'false' in the 'selected' property
 						if (this._selectedSection.selected === false) {

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -13,8 +13,8 @@
 			if (this !== window) {
 				this.lifecycle({
 					created: function(root) {
-						this.root = root;
-						var selectedSection = this.selectedSection = this.querySelector('section');
+						this._root = root;
+						var selectedSection = this._selectedSection = this.querySelector('section');
 
 						// This setTimeout is to give the child sections time to upgrade to accordion-sections. The spec describes an 'upgrade' DOM event that should fire, but it doesn't, so this is a hack for the time being.
 						setTimeout(function() {

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -60,13 +60,9 @@
 				this.lifecycle({
 					created: function(root) {
 						// Define instance properties
+						this._root = root;
+						this._content = root.querySelector('div');
 						Object.defineProperties(this, {
-							_root: {
-								value: root
-							},
-							_content: {
-								value: root.querySelector('div')
-							},
 							_selected: {
 								value: false,
 								writable: true

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -16,7 +16,7 @@
 						// Set instance properties
 						this._selectedSection = this.querySelector('.selected') || this.querySelector('section');
 
-						// Select firstChild if it has been upgraded to accordion-section by looking for a value of 'false' in the 'selected' property
+						// Select default item if it has been upgraded to accordion-section by looking for a value of 'false' in the 'selected' property
 						if (this._selectedSection.selected === false) {
 							this._selectedSection.selected = true;
 						}

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -13,6 +13,7 @@
 			if (this !== window) {
 				this.lifecycle({
 					created: function(root) {
+						// Set instance properties
 						this._root = root;
 						this._selectedSection = this.querySelector('section');
 
@@ -23,17 +24,23 @@
 						}, 10);
 
 						// Attach listeners
-						this.addEventListener('click', function(event) {
-							var clickedSection = event.target.parentElement,
-								oldSelectedSection = this._selectedSection;
-							if (clickedSection.selected === false) {
-								oldSelectedSection.selected = false;
-								clickedSection.selected = true;
-								this._selectedSection = clickedSection;
-							}
-						});
+						this.addEventListener('click', this._onClick);
 					}
 				});
+
+				// Set prototype
+				this.generatedConstructor.prototype = {
+					_onClick: function _onClick(event) {
+						var clickedSection = event.target.parentElement,
+							oldSelectedSection = this._selectedSection;
+
+						if (clickedSection.selected === false) {
+							oldSelectedSection.selected = false;
+							clickedSection.selected = true;
+							this._selectedSection = clickedSection;
+						}
+					}
+				};
 			}
 		</script>
 	</element>
@@ -61,7 +68,7 @@
 			if (this !== window) {
 				this.lifecycle({
 					created: function(root) {
-						// Define instance properties
+						// Set instance properties
 						this._root = root;
 						this._content = root.querySelector('div');
 						Object.defineProperties(this, {
@@ -73,6 +80,7 @@
 					}
 				});
 
+				// Set prototype
 				this.generatedConstructor.prototype = {
 					get selected() {
 						return this._selected;

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -16,11 +16,15 @@
 						// Set instance properties
 						this._selectedSection = this.querySelector('section');
 
-						// This setTimeout is to give the child sections time to upgrade to accordion-sections. The spec describes an 'upgrade' DOM event that should fire, but it doesn't, so this is a hack for the time being.
-						var selectedSection = this._selectedSection;
-						setTimeout(function() {
-							selectedSection.selected = true;
-						}, 10);
+						// Select firstChild if it has been upgraded to accordion-section by looking for a value of 'false' in the 'selected' property
+						if (this._selectedSection.selected === false) {
+							this._selectedSection.selected = true;
+						}
+						else {
+							this._selectedSection.addEventListener('upgrade', function() {
+								this.selected = true;
+							});
+						}
 
 						// Attach listeners
 						this.addEventListener('click', this._onClick);
@@ -78,6 +82,11 @@
 								writable: true
 							}
 						});
+
+						this.dispatchEvent(new CustomEvent('upgrade', {
+							bubbles: false,
+							cancelable: false
+						}));
 					}
 				});
 

--- a/samples/accordion/accordion-component.html
+++ b/samples/accordion/accordion-component.html
@@ -14,7 +14,6 @@
 				this.lifecycle({
 					created: function(root) {
 						// Set instance properties
-						this._root = root;
 						this._selectedSection = this.querySelector('section');
 
 						// This setTimeout is to give the child sections time to upgrade to accordion-sections. The spec describes an 'upgrade' DOM event that should fire, but it doesn't, so this is a hack for the time being.
@@ -72,7 +71,6 @@
 				this.lifecycle({
 					created: function(root) {
 						// Set instance properties
-						this._root = root;
 						this._content = root.querySelector('div');
 						Object.defineProperties(this, {
 							_selected: {

--- a/samples/accordion/index.html
+++ b/samples/accordion/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Accordion Component Example</title>
+	<link rel="components" href="accordion-component.html">
+	<script src="../../src/components-polyfill.js"></script>
+	<style>
+		/* These styles are based on the CSS accordion here:
+		 * http://www.hongkiat.com/blog/css-content-accordion/
+		 */
+		html {
+			overflow-y: scroll;
+		}
+		body {
+			font-family: sans-serif;
+			font-size: 13px;
+		}
+		.accordion {
+			width: 830px;
+			overflow: hidden;
+			margin: 10px auto;
+			padding: 10px;
+			color: #474747;
+			background: #414141;
+		}
+		.accordion section {
+			overflow: hidden;
+			margin-bottom: 6px;
+			padding: 10px;
+			color: #333;
+			background: white;
+		}
+		.accordion section:last-of-type {
+			margin-bottom: 0;
+		}
+		.accordion h2 {
+			margin: -10px;
+			padding: 8px 10px;
+			font-size: 16px;
+			font-weight: normal;
+			color: #eee;
+			background: #333;
+		}
+		.accordion h2:hover {
+			background: #444;
+		}
+		.accordion .selected h2 {
+			color: inherit;
+			background: none;
+		}
+		.contact label {
+			display: block;
+		}
+	</style>
+</head>
+<body>
+	<h1>Accordion Component Example</h1>
+
+	<div is="accordion" class="accordion">
+		<section is="accordion-section">
+			<h2>About Us</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id lobortis massa. Nunc viverra velit leo, sit amet elementum mi. Fusce posuere nunc a mi tempus malesuada. Curabitur facilisis rhoncus eros eget placerat. Aliquam semper mauris sit amet justo tempor nec lacinia magna molestie. Etiam placerat congue dolor vitae adipiscing. Aliquam ac erat lorem, ut iaculis justo. Etiam mattis dignissim gravida. Aliquam nec justo ante, non semper mi. Nulla consectetur interdum massa, vel porta enim vulputate sed. Maecenas elit quam, egestas eget placerat non, fringilla vel eros. Nam vehicula elementum nulla sed consequat. Phasellus eu erat enim. Praesent at magna non massa dapibus scelerisque in eu lorem.</p>
+		</section>
+
+		<section is="accordion-section">
+			<h2>Services</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id lobortis massa. Nunc viverra velit leo, sit amet elementum mi. Fusce posuere nunc a mi tempus malesuada. Curabitur facilisis rhoncus eros eget placerat.</p>
+			<p>Aliquam semper mauris sit amet justo tempor nec lacinia magna molestie. Etiam placerat congue dolor vitae adipiscing. Aliquam ac erat lorem, ut iaculis justo. Etiam mattis dignissim gravida. Aliquam nec justo ante, non semper mi. Nulla consectetur interdum massa, vel porta enim vulputate sed.</p>
+			<p>Maecenas elit quam, egestas eget placerat non, fringilla vel eros. Nam vehicula elementum nulla sed consequat. Phasellus eu erat enim. Praesent at magna non massa dapibus scelerisque in eu lorem.</p>
+		</section>
+
+		<section is="accordion-section">
+			<h2>Blog</h2>
+			<article>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id lobortis massa. Nunc viverra velit leo, sit amet elementum mi. Fusce posuere nunc a mi tempus malesuada. Curabitur facilisis rhoncus eros eget placerat.</p>
+			</article>
+			<article>
+				<p>Aliquam semper mauris sit amet justo tempor nec lacinia magna molestie. Etiam placerat congue dolor vitae adipiscing. Aliquam ac erat lorem, ut iaculis justo. Etiam mattis dignissim gravida. Aliquam nec justo ante, non semper mi. Nulla consectetur interdum massa, vel porta enim vulputate sed.</p>
+			</article>
+			<article>
+				<p>Maecenas elit quam, egestas eget placerat non, fringilla vel eros. Nam vehicula elementum nulla sed consequat. Phasellus eu erat enim. Praesent at magna non massa dapibus scelerisque in eu lorem.</p>
+			</article>
+		</section>
+
+		<section is="accordion-section">
+			<h2>Portfolio</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+			<ul>
+				<li>Suspendisse id lobortis massa. Nunc viverra velit leo, sit amet elementum mi</li>
+				<li>Fusce posuere nunc a mi tempus malesuada. Curabitur facilisis rhoncus eros eget placerat</li>
+				<li>Aliquam semper mauris sit amet justo tempor nec lacinia magna molestie. Etiam placerat congue dolor vitae adipiscing</li>
+				<li>Aliquam ac erat lorem, ut iaculis justo. Etiam mattis dignissim gravida</li>
+				<li>Aliquam nec justo ante, non semper mi. Nulla consectetur interdum massa, vel porta enim vulputate sed</li>
+				<li>Maecenas elit quam, egestas eget placerat non, fringilla vel eros. Nam vehicula elementum nulla sed consequat</li>
+				<li>Phasellus eu erat enim. Praesent at magna non massa dapibus scelerisque in eu lorem.</li>
+			</ul>
+		</section>
+
+		<section is="accordion-section">
+			<h2>Contact</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id lobortis massa.</p>
+			<form class="contact">
+				<label>Lorem<input type="text" /></label>
+				<label>Ipsum<input type="password" /></label>
+				<label>Dolor<input type="radio" /></label>
+				<label>Sit<input type="checkbox" /></label>
+				<input type="submit" />
+			</form>
+		</section>
+	</div>
+</body>
+</html>

--- a/samples/accordion/index.html
+++ b/samples/accordion/index.html
@@ -62,7 +62,7 @@
 			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id lobortis massa. Nunc viverra velit leo, sit amet elementum mi. Fusce posuere nunc a mi tempus malesuada. Curabitur facilisis rhoncus eros eget placerat. Aliquam semper mauris sit amet justo tempor nec lacinia magna molestie. Etiam placerat congue dolor vitae adipiscing. Aliquam ac erat lorem, ut iaculis justo. Etiam mattis dignissim gravida. Aliquam nec justo ante, non semper mi. Nulla consectetur interdum massa, vel porta enim vulputate sed. Maecenas elit quam, egestas eget placerat non, fringilla vel eros. Nam vehicula elementum nulla sed consequat. Phasellus eu erat enim. Praesent at magna non massa dapibus scelerisque in eu lorem.</p>
 		</section>
 
-		<section is="accordion-section">
+		<section is="accordion-section" class="selected">
 			<h2>Services</h2>
 			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse id lobortis massa. Nunc viverra velit leo, sit amet elementum mi. Fusce posuere nunc a mi tempus malesuada. Curabitur facilisis rhoncus eros eget placerat.</p>
 			<p>Aliquam semper mauris sit amet justo tempor nec lacinia magna molestie. Etiam placerat congue dolor vitae adipiscing. Aliquam ac erat lorem, ut iaculis justo. Etiam mattis dignissim gravida. Aliquam nec justo ante, non semper mi. Nulla consectetur interdum massa, vel porta enim vulputate sed.</p>


### PR DESCRIPTION
Obviously, I could have put more styles in the component itself, but I figured this way was the most flexible. If necessary, I could also make a styled-accordion sample or something. This is my first try at a real component, so let me know what I can do to improve. Specifically, is there a way to eliminate the "accordion-section" component so the user only has to worry about one "is" attribute?
